### PR TITLE
Fix Github links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/wildlyinaccurate/speedcurve-deploy.git"
+    "url": "git+https://github.com/SpeedCurve-Metrics/speedcurve-cli.git"
   },
   "author": "SpeedCurve <support@speedcurve.com> (https://speedcurve.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/wildlyinaccurate/speedcurve-deploy/issues"
+    "url": "https://github.com/SpeedCurve-Metrics/speedcurve-cli/issues"
   },
-  "homepage": "https://github.com/wildlyinaccurate/speedcurve-deploy#readme",
+  "homepage": "https://github.com/SpeedCurve-Metrics/speedcurve-cli#readme",
   "dependencies": {
     "@types/node": "^12.0.10",
     "@types/npmlog": "^4.1.1",


### PR DESCRIPTION
Adjust homepage, bugs and repository fields in package.json to match reality. These are rendered in the sidebar of https://www.npmjs.com/package/speedcurve and currently 404.

## Pre-merge checklist

- [x] All new code is documented with [JSDoc](http://usejsdoc.org/) tags
- [x] Any changes to the `docs/` directory have been committed
- [x] `npm run test` does not produce any errors
